### PR TITLE
Added shortcut for navigateForward

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Port of Resharper 9 key bindings for VS Code. Migration was originally done in t
 | ctrl+n | cmd+n | Quick Open | Yes | 
 | ctrl+m | cmd+m | Go to type Declaration | Yes | 
 | ctrl+- | cmd+- | Navigate Back | Yes | 
+| ctrl+shift+- | cmd+shift+- | Navigate Forward | Yes | 
 | ctrl+shift+alt+n | ctrl+shift+alt+n | Go to Symbol | Yes |
 | ctrl+w | cmd+w | Selection Grow | Yes | 
 | ctrl+shift+w | cmd+shift+w | Selection Shrink | Yes | 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
                 "command": "workbench.action.navigateBack"
             },
             {
+                "key": "ctrl+shift+-",
+                "mac": "cmd+shift+-",
+                "command": "workbench.action.navigateForward"
+            },
+            {
                 "key": "ctrl+shift+alt+n",
                 "mac": "ctrl+shift+alt+n",
                 "command": "workbench.action.gotoSymbol"


### PR DESCRIPTION
Added the sister command to navigateBack (navigateForward) to `CMD+SHIFT+-` / `CTRL+SHIFT+-`

This should fix Issue https://github.com/Microsoft/vscode-resharper-keybindings/issues/1

Probably worth noting there is already a built in short-cut assigned to `CTRL+SHIFT+-` for zoom out. 
Hopefully this takes precedence.